### PR TITLE
Removing wordwrap from xml Log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: node_js
 node_js:
   - stable
   - v4
-  - '0.12'
-  - '0.10'

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-var LINE_WIDTH = 100;
-
 export default function () {
     return {
         noColors:           true,
@@ -28,7 +26,7 @@ export default function () {
                 err = this.formatError(err, `${idx + 1}) `);
 
                 this.report += '\n';
-                this.report += this.wordWrap(err, 6, LINE_WIDTH);
+                this.report += this.indentString(err, 6);
                 this.report += '\n';
             });
 
@@ -77,7 +75,7 @@ export default function () {
                     .write('--')
                     .newline()
                     .setIndent(0)
-                    .write(this.wordWrap(msg, 6, LINE_WIDTH))
+                    .write(this.indentString(msg, 6))
                     .newline();
             });
 

--- a/test/data/report-with-colors.xml
+++ b/test/data/report-with-colors.xml
@@ -91,9 +91,7 @@
 
       ReferenceError: someOtherVar is not defined
     --
-      Was unable to take screenshots because the screenshot directory is not specified. To specify
-      it, use the "-s" or "--screenshots" command line option or the "screenshots" method of the
-      test runner in case you are using API.
+      Was unable to take screenshots because the screenshot directory is not specified. To specify it, use the "-s" or "--screenshots" command line option or the "screenshots" method of the test runner in case you are using API.
   ]]>
   </system-out>
 </testsuite>

--- a/test/data/report-without-colors.xml
+++ b/test/data/report-without-colors.xml
@@ -91,9 +91,7 @@
 
       ReferenceError: someOtherVar is not defined
     --
-      Was unable to take screenshots because the screenshot directory is not specified. To specify
-      it, use the "-s" or "--screenshots" command line option or the "screenshots" method of the
-      test runner in case you are using API.
+      Was unable to take screenshots because the screenshot directory is not specified. To specify it, use the "-s" or "--screenshots" command line option or the "screenshots" method of the test runner in case you are using API.
   ]]>
   </system-out>
 </testsuite>


### PR DESCRIPTION
Wordwrapping is best done in the system viewing the xml log.
Removing old node support from travisci.