### PR TITLE
Fixed duplicated number of failed tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ export default function () {
             this.write('<?xml version="1.0" encoding="UTF-8" ?>')
                 .newline()
                 .write(`<testsuite name="${name}" tests="${this.testCount}" failures="${failures}" skipped="${this.skipped}"` +
-                       ` errors="${failures}" time="${time}" timestamp="${endTime.toUTCString()}" >`)
+                       ` errors="0" time="${time}" timestamp="${endTime.toUTCString()}" >`)
                 .newline()
                 .write(this.report);
 

--- a/test/data/report-with-colors.xml
+++ b/test/data/report-with-colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="6" failures="2" skipped="1" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" >
+<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="6" failures="2" skipped="1" errors="0" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" >
   <testcase classname="First fixture" name="First test in first fixture (unstable) (screenshots: /screenshots/1445437598847)" time="74">
   </testcase>
   <testcase classname="First fixture" name="Second test in first fixture (screenshots: /screenshots/1445437598847)" time="74">

--- a/test/data/report-without-colors.xml
+++ b/test/data/report-without-colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="6" failures="2" skipped="1" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" >
+<testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="6" failures="2" skipped="1" errors="0" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" >
   <testcase classname="First fixture" name="First test in first fixture (unstable) (screenshots: /screenshots/1445437598847)" time="74">
   </testcase>
   <testcase classname="First fixture" name="Second test in first fixture (screenshots: /screenshots/1445437598847)" time="74">


### PR DESCRIPTION
- fix: each failed test produced 1 failure and additional 1 error in report file

This issue was was in Bitbucket pipelines where you can see always twice as much failures as actual number of failed tests.