### PR TITLE
fix: override lodash version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6719,12 +6719,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/publish-please/node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
-    },
     "node_modules/publish-please/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -10971,7 +10965,7 @@
         "chalk": "^1.1.1",
         "error-stack-parser": "^1.3.3",
         "highlight-es": "^1.0.0",
-        "lodash": "4.6.1 || ^4.16.1",
+        "lodash": "^4.17.21",
         "pinkie-promise": "^2.0.0"
       }
     },
@@ -12407,7 +12401,7 @@
       "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       }
     },
     "has": {
@@ -12623,7 +12617,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.21",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -14087,7 +14081,7 @@
         "elegant-status": "1.1.0",
         "inquirer": "6.2.0",
         "is-ci": "1.2.1",
-        "lodash": "4.17.20",
+        "lodash": "^4.17.21",
         "micromatch": "3.1.10",
         "node-emoji": "1.8.1",
         "osenv": "0.1.5",
@@ -14113,12 +14107,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -14975,7 +14963,7 @@
         "is-glob": "^2.0.1",
         "is-stream": "^2.0.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "log-update-async-hook": "^2.0.7",
         "make-dir": "^3.0.0",
         "mime-db": "^1.41.0",
@@ -15038,7 +15026,7 @@
             "callsite": "^1.0.0",
             "chalk": "^2.4.0",
             "highlight-es": "^1.0.0",
-            "lodash": "4.6.1 || ^4.16.1",
+            "lodash": "^4.17.21",
             "pinkie-promise": "^2.0.0"
           }
         },
@@ -15108,7 +15096,7 @@
         "fs-extra": "^10.0.0",
         "graceful-fs": "^4.1.11",
         "linux-platform-info": "^0.0.3",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "mkdirp": "^0.5.1",
         "mustache": "^2.1.2",
         "nanoid": "^3.1.31",
@@ -15228,7 +15216,7 @@
         "esotope-hammerhead": "0.6.1",
         "http-cache-semantics": "^4.1.0",
         "iconv-lite": "0.5.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "lru-cache": "2.6.3",
         "match-url-wildcard": "0.0.4",
         "merge-stream": "^1.0.1",
@@ -15308,7 +15296,7 @@
         "dedent": "^0.6.0",
         "highlight-es": "^1.0.0",
         "is-jquery-obj": "^0.1.0",
-        "lodash": "^4.14.0",
+        "lodash": "^4.17.21",
         "moment": "^2.14.1",
         "mustache": "^2.2.1",
         "os-family": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,11 @@
     "publish-please": "^5.5.2",
     "read-file-relative": "^1.2.0",
     "testcafe": "^1.18.6"
+  },
+  "overrides": {
+    "lodash": "^4.17.21"
+  },
+  "resolutions": {
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
This is the fast fix because we're waiting for https://github.com/inikulin/publish-please/pull/99