### PR TITLE
feat: possibility to pass basePath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ npm install testcafe-reporter-xunit
 
 ## Usage
 
+### CLI
 When you run tests from the command line, specify the reporter name by using the `--reporter` option:
 
 ```
 testcafe chrome 'path/to/test/file.js' --reporter xunit
 ```
 
-
+### Test Runner API
 When you use API, pass the reporter name to the `reporter()` method:
 
 ```js
@@ -36,6 +37,17 @@ testCafe
     .reporter('xunit') // <-
     .run();
 ```
+### Configuration file
 
+```js
+reporter: [
+    {
+      name: 'xunit',
+      output: <path-for-xml-report>, // string
+      options: { basePath: <your-repository-root>, /* string */ }
+    },
+    ...
+]
+```
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,10 @@
-module.exports = function () {
+const { relative } = require('node:path');
+
+module.exports = function (options) {
+    function resolvePath (path) {
+        return options && options.basePath ? relative(options.basePath, path) : path;
+    }
+
     return {
         noColors:       true,
         report:         '',
@@ -14,8 +20,8 @@ module.exports = function () {
             this.testCount = testCount;
         },
 
-        reportFixtureStart (name, path) {
-            this.currentFixture = { name: this.escapeHtml(name), path: path };
+        reportFixtureStart (name, absolutePath) {
+            this.currentFixture = { name: this.escapeHtml(name), path: resolvePath(absolutePath) };
         },
 
         _renderErrors (errs) {
@@ -46,7 +52,7 @@ module.exports = function () {
             name = this.escapeHtml(name);
 
             var openTag = `<testcase classname="${this.currentFixture.name}" ` +
-                          `file="${this.currentFixture.path}" ` +  
+                          `file="${this.currentFixture.path}" ` +
                           `name="${name}" time="${testRunInfo.durationMs / 1000}">\n`;
 
             this.report += this.indentString(openTag, 2);


### PR DESCRIPTION
Hello
Because of [this comment](https://github.com/DevExpress/testcafe-reporter-xunit/issues/24#issuecomment-1439545230) I've created this MR.

![image](https://user-images.githubusercontent.com/44318220/220979211-6fc72941-ccc8-4dd7-85ea-2384b1265f15.png)

It already correct works for js config file. In my case, I have typescript version of.
I have to type config object as `Partial<TestCafeConfigurationOptions> & { hooks: any }`, unfortunately
it knows nothing about `options` possibility for reporters, but it already [used](https://github.com/DevExpress/testcafe/blob/master/src/reporter/index.ts#L261)

Notes:
If we agreed to change only reporter's repository, then I'm not able to support `cli` and `createRunner`