### PR TITLE
Add a failing test for producing valid XML

### DIFF
--- a/test/data/report-with-colors.xml
+++ b/test/data/report-with-colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="6" failures="2" skipped="1" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" >
-  <testcase classname="First fixture" file="./fixture1.js" name="First test in first fixture (unstable) (screenshots: /screenshots/1445437598847)" time="74">
+  <testcase classname="First fixture" file="./fixture1.js" name="�First test in first fixture (unstable) (screenshots: /screenshots/1445437598847)" time="74">
   </testcase>
   <testcase classname="First fixture" file="./fixture1.js" name="Second test in first fixture (screenshots: /screenshots/1445437598847)" time="74">
     <failure>

--- a/test/data/report-without-colors.xml
+++ b/test/data/report-without-colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuite name="TestCafe Tests: Chrome 41.0.2227 / Mac OS X 10.10.1, Firefox 47 / Mac OS X 10.10.1" tests="6" failures="2" skipped="1" errors="2" time="925" timestamp="Thu, 01 Jan 1970 00:15:25 GMT" >
-  <testcase classname="First fixture" file="./fixture1.js" name="First test in first fixture (unstable) (screenshots: /screenshots/1445437598847)" time="74">
+  <testcase classname="First fixture" file="./fixture1.js" name="�First test in first fixture (unstable) (screenshots: /screenshots/1445437598847)" time="74">
   </testcase>
   <testcase classname="First fixture" file="./fixture1.js" name="Second test in first fixture (screenshots: /screenshots/1445437598847)" time="74">
     <failure>

--- a/test/utils/reporter-test-calls.js
+++ b/test/utils/reporter-test-calls.js
@@ -32,7 +32,7 @@ module.exports = [
     {
         method: 'reportTestDone',
         args:   [
-            'First test in first fixture',
+            '\x1BFirst test in first fixture',
             {
                 errs:           [],
                 durationMs:     74000,


### PR DESCRIPTION
I replaced the illegal character in the expected XML outputs for the other tests with the replacement character (U+FFFD) as that's probably the correct behavior.

This allows reproducing the bug reported here: #33

Note: you will need `xmlstarlet` installed for this test (it's available in APT and homebrew, and probably anywhere else). I tried to use an XML validator that was a node package, but the one I tried said that the document was valid despite containing invalid characters, so I gave up on that approach.